### PR TITLE
Add MQTT connection tester for watchOS

### DIFF
--- a/WatchNet Watch App/ContentView.swift
+++ b/WatchNet Watch App/ContentView.swift
@@ -2,17 +2,25 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject var browser = BonjourBrowser()
+    @StateObject var connector = MQTTConnector()
 
     var body: some View {
         VStack {
             Text("Bonjour MQTT Discovery")
                 .font(.headline)
-            Button("Start Browsing") {
-                browser.startBrowsing()
+            Button(browser.isBrowsing ? "Stop Browsing" : "Start Browsing") {
+                if browser.isBrowsing {
+                    browser.stopBrowsing()
+                } else {
+                    browser.startBrowsing()
+                }
             }
-            List(browser.foundServices, id: \.self) { service in
-                Text(service)
+            List(browser.services) { service in
+                Button(service.name) {
+                    connector.connect(to: service.endpoint)
+                }
             }
+            Text("MQTT state: \(String(describing: connector.state))")
         }
         .padding()
     }

--- a/WatchNet Watch App/MQTTConnector.swift
+++ b/WatchNet Watch App/MQTTConnector.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Network
+
+class MQTTConnector: ObservableObject {
+    @Published var state: NWConnection.State = .setup
+    private var connection: NWConnection?
+
+    func connect(to endpoint: NWEndpoint) {
+        let params = NWParameters.tcp
+        let connection = NWConnection(to: endpoint, using: params)
+        connection.stateUpdateHandler = { [weak self] newState in
+            DispatchQueue.main.async {
+                self?.state = newState
+                print("Connection state: \(newState)")
+            }
+        }
+        self.connection = connection
+        connection.start(queue: .main)
+    }
+
+    func disconnect() {
+        connection?.cancel()
+        connection = nil
+    }
+}


### PR DESCRIPTION
## Summary
- store endpoint info while browsing Bonjour services
- add connector object to attempt MQTT connection using `NWConnection`
- update UI to start/stop browsing and initiate connection

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684487a6fd6c832a99b12e7169b87a37