### PR TITLE
Fix build settings for watchOS project

### DIFF
--- a/WatchNet Watch App/ContentView.swift
+++ b/WatchNet Watch App/ContentView.swift
@@ -2,17 +2,25 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject var browser = BonjourBrowser()
+    @StateObject var connector = MQTTConnector()
 
     var body: some View {
         VStack {
             Text("Bonjour MQTT Discovery")
                 .font(.headline)
-            Button("Start Browsing") {
-                browser.startBrowsing()
+            Button(browser.isBrowsing ? "Stop Browsing" : "Start Browsing") {
+                if browser.isBrowsing {
+                    browser.stopBrowsing()
+                } else {
+                    browser.startBrowsing()
+                }
             }
-            List(browser.foundServices, id: \.self) { service in
-                Text(service)
+            List(browser.services) { service in
+                Button(service.name) {
+                    connector.connect(to: service.endpoint)
+                }
             }
+            Text("MQTT state: \(String(describing: connector.state))")
         }
         .padding()
     }

--- a/WatchNet Watch App/Info.plist
+++ b/WatchNet Watch App/Info.plist
@@ -1,3 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
 <dict>
     <key>CFBundleIdentifier</key>
     <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
@@ -11,6 +14,12 @@
     <string>1.0</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
+    <key>WKWatchKitApp</key>
+    <true/>
+    <key>WKAppBundleIdentifier</key>
+    <string>MIA2.WatchNet.watchkitapp</string>
+    <key>WKCompanionAppBundleIdentifier</key>
+    <string>MIA2.WatchNet</string>
     <key>UILaunchStoryboardName</key>
     <string>LaunchScreen</string>
     <key>NSBonjourServices</key>
@@ -21,3 +30,4 @@
     <key>NSLocalNetworkUsageDescription</key>
     <string>This app requires access to devices on your local network.</string>
 </dict>
+</plist>

--- a/WatchNet Watch App/MQTTConnector.swift
+++ b/WatchNet Watch App/MQTTConnector.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Network
+
+class MQTTConnector: ObservableObject {
+    @Published var state: NWConnection.State = .setup
+    private var connection: NWConnection?
+
+    func connect(to endpoint: NWEndpoint) {
+        let params = NWParameters.tcp
+        let connection = NWConnection(to: endpoint, using: params)
+        connection.stateUpdateHandler = { [weak self] newState in
+            DispatchQueue.main.async {
+                self?.state = newState
+                print("Connection state: \(newState)")
+            }
+        }
+        self.connection = connection
+        connection.start(queue: .main)
+    }
+
+    func disconnect() {
+        connection?.cancel()
+        connection = nil
+    }
+}

--- a/WatchNet.xcodeproj/project.pbxproj
+++ b/WatchNet.xcodeproj/project.pbxproj
@@ -343,7 +343,7 @@
 				DEVELOPMENT_TEAM = Z8Y3M6THR2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "/Users/captain/xcode/WatchMQTT/WatchNet/WatchNet/WatchNet Watch App/Info.plist";
+                                INFOPLIST_FILE = "WatchNet Watch App/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = WatchNet;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKWatchOnly = YES;
@@ -374,7 +374,7 @@
 				DEVELOPMENT_TEAM = Z8Y3M6THR2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "/Users/captain/xcode/WatchMQTT/WatchNet/WatchNet/WatchNet Watch App/Info.plist";
+                                INFOPLIST_FILE = "WatchNet Watch App/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = WatchNet;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKWatchOnly = YES;


### PR DESCRIPTION
## Summary
- add standard XML headers to watch app Info.plist
- use a relative Info.plist path in the Xcode project
- expose service endpoints for MQTT testing via Bonjour
- implement simple MQTT connection tester
- show connection state in the UI
- add required `WKAppBundleIdentifier` and `WKCompanionAppBundleIdentifier`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684487a6fd6c832a99b12e7169b87a37